### PR TITLE
Removing the master and slave words

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'nova'

--- a/nova/compute/disk.py
+++ b/nova/compute/disk.py
@@ -26,7 +26,7 @@ from nova.utils import execute
 
 def partition(infile, outfile, local_bytes=0, local_type='ext2'):
     """Takes a single partition represented by infile and writes a bootable drive image into outfile.
-    The first 63 sectors (0-62) of the resulting image is a master boot record.
+    The first 63 sectors (0-62) of the resulting image is a main boot record.
     Infile becomes the first primary partition.
     If local bytes is specified, a second primary partition is created and formatted as ext2.
     In the diagram below, dashes represent drive sectors.

--- a/vendor/Twisted-10.0.0/doc/core/examples/row_example.py
+++ b/vendor/Twisted-10.0.0/doc/core/examples/row_example.py
@@ -86,7 +86,7 @@ dbpool = adbapi.ConnectionPool("pyPgSQL.PgSQL", database="test")
 #dbpool = adbapi.ConnectionPool("sqlite", db="test")
 
 # use this line for Interbase / Firebird
-#dbpool = adbapi.ConnectionPool("kinterbasdb", dsn="localhost:/test.gdb",user="SYSDBA",password="masterkey")
+#dbpool = adbapi.ConnectionPool("kinterbasdb", dsn="localhost:/test.gdb",user="SYSDBA",password="mainkey")
 
 # use this for MySQL
 #dbpool = adbapi.ConnectionPool("MySQLdb", db="test", passwd="pass")

--- a/vendor/Twisted-10.0.0/doc/core/howto/listings/pb/cache_sender.py
+++ b/vendor/Twisted-10.0.0/doc/core/howto/listings/pb/cache_sender.py
@@ -6,7 +6,7 @@
 from twisted.spread import pb, jelly
 from twisted.python import log
 from twisted.internet import reactor
-from cache_classes import MasterDuckPond
+from cache_classes import MainDuckPond
 
 class Sender:
     def __init__(self, pond):
@@ -36,10 +36,10 @@ class Sender:
         reactor.stop()
 
 def main():
-    master = MasterDuckPond(["one duck", "two duck"])
-    master.count()
+    main = MainDuckPond(["one duck", "two duck"])
+    main.count()
 
-    sender = Sender(master)
+    sender = Sender(main)
     factory = pb.PBClientFactory()
     reactor.connectTCP("localhost", 8800, factory)
     deferred = factory.getRootObject()

--- a/vendor/Twisted-10.0.0/doc/web/examples/silly-web.py
+++ b/vendor/Twisted-10.0.0/doc/web/examples/silly-web.py
@@ -1,17 +1,17 @@
 # This shows an example of a bare-bones distributed web
 # set up.
-# The "master" and "slave" parts will usually be in different files
+# The "main" and "subordinate" parts will usually be in different files
 # -- they are here together only for brevity of illustration 
 
 from twisted.internet import reactor, protocol
 from twisted.web import server, distrib, static
 from twisted.spread import pb
 
-# The "master" server
+# The "main" server
 site = server.Site(distrib.ResourceSubscription('unix', '.rp'))
 reactor.listenTCP(19988, site)
 
-# The "slave" server
+# The "subordinate" server
 fact = pb.PBServerFactory(distrib.ResourcePublisher(server.Site(static.File('static'))))
 
 reactor.listenUNIX('./.rp', fact)

--- a/vendor/Twisted-10.0.0/twisted/conch/scripts/tkconch.py
+++ b/vendor/Twisted-10.0.0/twisted/conch/scripts/tkconch.py
@@ -25,7 +25,7 @@ class TkConchMenu(Tkinter.Frame):
         ## Standard heading: initialization
         apply(Tkinter.Frame.__init__, (self,) + args, params)
 
-        self.master.title('TkConch')
+        self.main.title('TkConch')
         self.localRemoteVar = Tkinter.StringVar()
         self.localRemoteVar.set('local')
 
@@ -85,7 +85,7 @@ class TkConchMenu(Tkinter.Frame):
         self.grid_rowconfigure(6, weight=1, minsize=64)
         self.grid_columnconfigure(2, weight=1, minsize=2)
 
-        self.master.protocol("WM_DELETE_WINDOW", sys.exit)
+        self.main.protocol("WM_DELETE_WINDOW", sys.exit)
         
 
     def getIdentityFile(self):
@@ -159,8 +159,8 @@ class TkConchMenu(Tkinter.Frame):
             tkMessageBox.showerror('TkConch', 'Missing host or username.')
             finished = 0
         if finished:
-            self.master.quit()
-            self.master.destroy()        
+            self.main.quit()
+            self.main.destroy()        
             if options['log']:
                 realout = sys.stdout
                 log.startLogging(sys.stderr)
@@ -174,8 +174,8 @@ class TkConchMenu(Tkinter.Frame):
             port = int(options['port'] or 22)
             log.msg((host,port))
             reactor.connectTCP(host, port, SSHClientFactory())
-            frame.master.deiconify()
-            frame.master.title('%s@%s - TkConch' % (options['user'], options['host']))
+            frame.main.deiconify()
+            frame.main.title('%s@%s - TkConch' % (options['user'], options['host']))
         else:
             self.focus()
 

--- a/vendor/Twisted-10.0.0/twisted/conch/unix.py
+++ b/vendor/Twisted-10.0.0/twisted/conch/unix.py
@@ -166,10 +166,10 @@ class SSHSessionForUnixConchUser:
         self.environ['TERM'] = term
         self.winSize = windowSize
         self.modes = modes
-        master, slave = pty.openpty()
-        ttyname = os.ttyname(slave)
+        main, subordinate = pty.openpty()
+        ttyname = os.ttyname(subordinate)
         self.environ['SSH_TTY'] = ttyname 
-        self.ptyTuple = (master, slave, ttyname)
+        self.ptyTuple = (main, subordinate, ttyname)
 
     def openShell(self, proto):
         from twisted.internet import reactor

--- a/vendor/Twisted-10.0.0/twisted/internet/defer.py
+++ b/vendor/Twisted-10.0.0/twisted/internet/defer.py
@@ -201,7 +201,7 @@ class Deferred:
         """
         Add a pair of callbacks (success and error) to this L{Deferred}.
 
-        These will be executed when the 'master' callback is run.
+        These will be executed when the 'main' callback is run.
         """
         assert callable(callback)
         assert errback == None or callable(errback)

--- a/vendor/Twisted-10.0.0/twisted/internet/interfaces.py
+++ b/vendor/Twisted-10.0.0/twisted/internet/interfaces.py
@@ -471,7 +471,7 @@ class IReactorProcess(Interface):
                     POSIX systems.)
 
         @param usePTY: if true, run this process in a pseudo-terminal.
-                       optionally a tuple of C{(masterfd, slavefd, ttyname)},
+                       optionally a tuple of C{(mainfd, subordinatefd, ttyname)},
                        in which case use those file descriptors.
                        (Not available on all systems.)
 

--- a/vendor/Twisted-10.0.0/twisted/mail/bounce.py
+++ b/vendor/Twisted-10.0.0/twisted/mail/bounce.py
@@ -14,7 +14,7 @@ import os
 from twisted.mail import smtp
 
 BOUNCE_FORMAT = """\
-From: postmaster@%(failedDomain)s
+From: postmain@%(failedDomain)s
 To: %(failedFrom)s
 Subject: Returned Mail: see transcript for details
 Message-ID: %(messageID)s

--- a/vendor/Twisted-10.0.0/twisted/mail/maildir.py
+++ b/vendor/Twisted-10.0.0/twisted/mail/maildir.py
@@ -433,12 +433,12 @@ class MaildirDirdbmDomain(AbstractMaildirDomain):
     portal = None
     _credcheckers = None
 
-    def __init__(self, service, root, postmaster=0):
+    def __init__(self, service, root, postmain=0):
         """Initialize
 
         The first argument is where the Domain directory is rooted.
         The second is whether non-existing addresses are simply
-        forwarded to postmaster instead of outright bounce
+        forwarded to postmain instead of outright bounce
 
         The directory structure of a MailddirDirdbmDomain is:
 
@@ -450,20 +450,20 @@ class MaildirDirdbmDomain(AbstractMaildirDomain):
         if not os.path.exists(dbm):
             os.makedirs(dbm)
         self.dbm = dirdbm.open(dbm)
-        self.postmaster = postmaster
+        self.postmain = postmain
 
     def userDirectory(self, name):
         """Get the directory for a user
 
         If the user exists in the dirdbm file, return the directory
         os.path.join(root, name), creating it if necessary.
-        Otherwise, returns postmaster's mailbox instead if bounces
-        go to postmaster, otherwise return None
+        Otherwise, returns postmain's mailbox instead if bounces
+        go to postmain, otherwise return None
         """
         if not self.dbm.has_key(name):
-            if not self.postmaster:
+            if not self.postmain:
                 return None
-            name = 'postmaster'
+            name = 'postmain'
         dir = os.path.join(self.root, name)
         if not os.path.exists(dir):
             initializeMaildir(dir)

--- a/vendor/Twisted-10.0.0/twisted/mail/scripts/mailmail.py
+++ b/vendor/Twisted-10.0.0/twisted/mail/scripts/mailmail.py
@@ -295,7 +295,7 @@ def sendmail(host, options, ident):
 
 def senderror(failure, options):
     recipient = [options.sender]
-    sender = '"Internally Generated Message (%s)"<postmaster@%s>' % (sys.argv[0], smtp.DNSNAME)
+    sender = '"Internally Generated Message (%s)"<postmain@%s>' % (sys.argv[0], smtp.DNSNAME)
     error = StringIO.StringIO()
     failure.printTraceback(file=error)
     body = StringIO.StringIO(ERROR_FMT % error.getvalue())

--- a/vendor/Twisted-10.0.0/twisted/mail/tap.py
+++ b/vendor/Twisted-10.0.0/twisted/mail/tap.py
@@ -87,11 +87,11 @@ class Options(usage.Options):
             raise usage.UsageError("Specify a domain before specifying users")
     opt_u = opt_user
 
-    def opt_bounce_to_postmaster(self):
-        """undelivered mails are sent to the postmaster
+    def opt_bounce_to_postmain(self):
+        """undelivered mails are sent to the postmain
         """
-        self.last_domain.postmaster = 1
-    opt_b = opt_bounce_to_postmaster
+        self.last_domain.postmain = 1
+    opt_b = opt_bounce_to_postmain
 
     def opt_aliases(self, filename):
         """Specify an aliases(5) file to use for this domain"""

--- a/vendor/Twisted-10.0.0/twisted/mail/test/test_bounce.py
+++ b/vendor/Twisted-10.0.0/twisted/mail/test/test_bounce.py
@@ -25,7 +25,7 @@ Subject: test
         self.assertEquals(to, 'moshez@example.com')
         mess = rfc822.Message(cStringIO.StringIO(s))
         self.assertEquals(mess['To'], 'moshez@example.com')
-        self.assertEquals(mess['From'], 'postmaster@example.org')
+        self.assertEquals(mess['From'], 'postmain@example.org')
         self.assertEquals(mess['subject'], 'Returned Mail: see transcript for details')
 
     def testBounceMIME(self):

--- a/vendor/Twisted-10.0.0/twisted/names/test/test_names.py
+++ b/vendor/Twisted-10.0.0/twisted/names/test/test_names.py
@@ -58,7 +58,7 @@ reverse_soa = dns.Record_SOA(
 
 my_soa = dns.Record_SOA(
     mname = 'my-domain.com',
-    rname = 'postmaster.test-domain.com',
+    rname = 'postmain.test-domain.com',
     serial = 130,
     refresh = 12345,
     minimum = 1,

--- a/vendor/Twisted-10.0.0/twisted/names/topfiles/setup.py
+++ b/vendor/Twisted-10.0.0/twisted/names/topfiles/setup.py
@@ -40,7 +40,7 @@ Twisted Names is both a domain name server as well as a client
 resolver library. Twisted Names comes with an "out of the box"
 nameserver which can read most BIND-syntax zone files as well as a
 simple Python-based configuration format. Twisted Names can act as an
-authoritative server, perform zone transfers from a master to act as a
+authoritative server, perform zone transfers from a main to act as a
 secondary, act as a caching nameserver, or any combination of
 these. Twisted Names' client resolver library provides functions to
 query for all commonly used record types as well as a replacement for

--- a/vendor/Twisted-10.0.0/twisted/news/nntp.py
+++ b/vendor/Twisted-10.0.0/twisted/news/nntp.py
@@ -524,7 +524,7 @@ class NNTPServer(basic.LineReceiver):
     ]
 
     def __init__(self):
-        self.servingSlave = 0
+        self.servingSubordinate = 0
 
 
     def connectionMade(self):
@@ -936,7 +936,7 @@ class NNTPServer(basic.LineReceiver):
     def do_MODE(self, cmd):
         cmd = cmd.strip().upper()
         if cmd == 'READER':
-            self.servingSlave = 0
+            self.servingSubordinate = 0
             self.sendLine('200 Hello, you can post')
         elif cmd == 'STREAM':
             self.sendLine('500 Command not understood')
@@ -957,8 +957,8 @@ class NNTPServer(basic.LineReceiver):
     
     
     def do_SLAVE(self):
-        self.sendLine('202 slave status noted')
-        self.servingeSlave = 1
+        self.sendLine('202 subordinate status noted')
+        self.servingeSubordinate = 1
 
 
     def do_XPATH(self, article):

--- a/vendor/Twisted-10.0.0/twisted/plugin.py
+++ b/vendor/Twisted-10.0.0/twisted/plugin.py
@@ -233,7 +233,7 @@ def pluginPackagePaths(name):
     #
     # Note as well that only '__init__.py' will be considered to make a
     # directory a package (and thus exclude it from this list).  This means
-    # that if you create a master plugin package which has some other kind of
+    # that if you create a main plugin package which has some other kind of
     # __init__ (eg, __init__.pyc) it will be incorrectly treated as a
     # supplementary plugin directory.
     return [

--- a/vendor/Twisted-10.0.0/twisted/scripts/tkunzip.py
+++ b/vendor/Twisted-10.0.0/twisted/scripts/tkunzip.py
@@ -29,7 +29,7 @@ from twisted.python import failure, log, zipstream, util, usage, log
 import os.path
 
 class ProgressBar:
-    def __init__(self, master=None, orientation="horizontal",
+    def __init__(self, main=None, orientation="horizontal",
                  min=0, max=100, width=100, height=18,
                  doLabel=1, appearance="sunken",
                  fillColor="blue", background="gray",
@@ -37,7 +37,7 @@ class ProgressBar:
                  labelText="", labelFormat="%d%%",
                  value=0, bd=2):
         # preserve various values
-        self.master=master
+        self.main=main
         self.orientation=orientation
         self.min=min
         self.max=max
@@ -51,7 +51,7 @@ class ProgressBar:
         self.labelText=labelText
         self.labelFormat=labelFormat
         self.value=value
-        self.frame=Frame(master, relief=appearance, bd=bd)
+        self.frame=Frame(main, relief=appearance, bd=bd)
         self.canvas=Canvas(self.frame, height=height, width=width, bd=0,
                            highlightthickness=0, background=background)
         self.scale=self.canvas.create_rectangle(0, 0, width, height,

--- a/vendor/Twisted-10.0.0/twisted/spread/ui/tkutil.py
+++ b/vendor/Twisted-10.0.0/twisted/spread/ui/tkutil.py
@@ -18,12 +18,12 @@ import string
 #errorFont = Font("-adobe-courier-medium-o-normal-*-*-120-*-*-m-*-iso8859-1")
 
 class _QueryPassword(_QueryString):
-    def body(self, master):
+    def body(self, main):
 
-        w = Label(master, text=self.prompt, justify=LEFT)
+        w = Label(main, text=self.prompt, justify=LEFT)
         w.grid(row=0, padx=5, sticky=W)
 
-        self.entry = Entry(master, name="entry",show="*")
+        self.entry = Entry(main, name="entry",show="*")
         self.entry.grid(row=1, padx=5, sticky=W+E)
 
         if self.initialvalue:
@@ -195,7 +195,7 @@ class CList(Frame):
         apply(self._callall,("yview",)+args)
 
 class ProgressBar:
-    def __init__(self, master=None, orientation="horizontal",
+    def __init__(self, main=None, orientation="horizontal",
                  min=0, max=100, width=100, height=18,
                  doLabel=1, appearance="sunken",
                  fillColor="blue", background="gray",
@@ -203,7 +203,7 @@ class ProgressBar:
                  labelText="", labelFormat="%d%%",
                  value=0, bd=2):
         # preserve various values
-        self.master=master
+        self.main=main
         self.orientation=orientation
         self.min=min
         self.max=max
@@ -217,7 +217,7 @@ class ProgressBar:
         self.labelText=labelText
         self.labelFormat=labelFormat
         self.value=value
-        self.frame=Frame(master, relief=appearance, bd=bd)
+        self.frame=Frame(main, relief=appearance, bd=bd)
         self.canvas=Canvas(self.frame, height=height, width=width, bd=0,
                            highlightthickness=0, background=background)
         self.scale=self.canvas.create_rectangle(0, 0, width, height,

--- a/vendor/Twisted-10.0.0/twisted/test/test_iutils.py
+++ b/vendor/Twisted-10.0.0/twisted/test/test_iutils.py
@@ -131,7 +131,7 @@ class ProcessUtilsTests(unittest.TestCase):
         it to exit.
         """
         # Use SIGKILL here because it's guaranteed to be delivered. Using
-        # SIGHUP might not work in, e.g., a buildbot slave run under the
+        # SIGHUP might not work in, e.g., a buildbot subordinate run under the
         # 'nohup' command.
         scriptFile = self.makeSourceFile([
             "import sys, os, signal",

--- a/vendor/Twisted-10.0.0/twisted/test/test_process.py
+++ b/vendor/Twisted-10.0.0/twisted/test/test_process.py
@@ -1768,7 +1768,7 @@ class MockProcessTestCase(unittest.TestCase):
 
     def test_mockForkErrorPTYGivenFDs(self):
         """
-        If a tuple is passed to C{usePTY} to specify slave and master file
+        If a tuple is passed to C{usePTY} to specify subordinate and main file
         descriptors and that C{os.fork} raises an exception, these file
         descriptors aren't closed.
         """

--- a/vendor/Twisted-10.0.0/twisted/test/test_tcp.py
+++ b/vendor/Twisted-10.0.0/twisted/test/test_tcp.py
@@ -1130,15 +1130,15 @@ class ConnectionLosingProtocol(protocol.Protocol):
     def connectionMade(self):
         self.transport.write("1")
         self.transport.loseConnection()
-        self.master._connectionMade()
-        self.master.ports.append(self.transport)
+        self.main._connectionMade()
+        self.main.ports.append(self.transport)
 
 
 
 class NoopProtocol(protocol.Protocol):
     def connectionMade(self):
         self.d = defer.Deferred()
-        self.master.serverConns.append(self.d)
+        self.main.serverConns.append(self.d)
 
     def connectionLost(self, reason):
         self.d.callback(True)

--- a/vendor/Twisted-10.0.0/twisted/words/im/interfaces.py
+++ b/vendor/Twisted-10.0.0/twisted/words/im/interfaces.py
@@ -16,7 +16,7 @@ from twisted.words.im import locals
 # Persons have Conversation components
 # Groups have GroupConversation components
 # Persons and Groups are associated with specific Accounts
-# At run-time, Clients/Accounts are slaved to a User Interface
+# At run-time, Clients/Accounts are subordinated to a User Interface
 #   (Note: User may be a bot, so don't assume all UIs are built on gui toolkits)
 
 

--- a/vendor/Twisted-10.0.0/twisted/words/protocols/irc.py
+++ b/vendor/Twisted-10.0.0/twisted/words/protocols/irc.py
@@ -2020,7 +2020,7 @@ class IRCClient(basic.LineReceiver):
             self.ctcpMakeReply(nick, [('USERINFO', self.userinfo)])
 
     def ctcpQuery_CLIENTINFO(self, user, channel, data):
-        """A master index of what CTCP tags this client knows.
+        """A main index of what CTCP tags this client knows.
 
         If no arguments are provided, respond with a list of known tags.
         If an argument is provided, provide human-readable help on

--- a/vendor/boto/boto/emr/connection.py
+++ b/vendor/boto/boto/emr/connection.py
@@ -129,8 +129,8 @@ class EmrConnection(AWSQueryConnection):
         return self.get_object('AddJobFlowSteps', params, RunJobFlowResponse)
 
     def run_jobflow(self, name, log_uri, ec2_keyname=None, availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     steps=[]):
@@ -145,10 +145,10 @@ class EmrConnection(AWSQueryConnection):
         :param ec2_keyname: EC2 key used for the instances
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
         :type action_on_failure: str
@@ -171,7 +171,7 @@ class EmrConnection(AWSQueryConnection):
 
         # Instance args
         instance_params = self._build_instance_args(ec2_keyname, availability_zone,
-                                                    master_instance_type, slave_instance_type,
+                                                    main_instance_type, subordinate_instance_type,
                                                     num_instances, keep_alive)
         params.update(instance_params)
 
@@ -218,11 +218,11 @@ class EmrConnection(AWSQueryConnection):
                 params['Steps.memeber.%s.%s' % (i+1, key)] = value
         return params
 
-    def _build_instance_args(self, ec2_keyname, availability_zone, master_instance_type,
-                             slave_instance_type, num_instances, keep_alive):
+    def _build_instance_args(self, ec2_keyname, availability_zone, main_instance_type,
+                             subordinate_instance_type, num_instances, keep_alive):
         params = {
-            'Instances.MasterInstanceType' : master_instance_type,
-            'Instances.SlaveInstanceType' : slave_instance_type,
+            'Instances.MainInstanceType' : main_instance_type,
+            'Instances.SubordinateInstanceType' : subordinate_instance_type,
             'Instances.InstanceCount' : num_instances,
             'Instances.KeepJobFlowAliveWhenNoSteps' : str(keep_alive).lower()
         }

--- a/vendor/boto/boto/rds/__init__.py
+++ b/vendor/boto/boto/rds/__init__.py
@@ -80,7 +80,7 @@ class RDSConnection(AWSQueryConnection):
         return self.get_list('DescribeDBInstances', params, [('DBInstance', DBInstance)])
 
     def create_dbinstance(self, id, allocated_storage, instance_class,
-                          master_username, master_password, port=3306,
+                          main_username, main_password, port=3306,
                           engine='MySQL5.1', db_name=None, param_group=None,
                           security_groups=None, availability_zone=None,
                           preferred_maintenance_window=None,
@@ -108,13 +108,13 @@ class RDSConnection(AWSQueryConnection):
         :type engine: str
         :param engine: Name of database engine. Must be MySQL5.1 for now.
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
                                 Must be 1-15 alphanumeric characters, first must be
                                 a letter.
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-16 alphanumeric characters.
 
         :type port: int
@@ -161,8 +161,8 @@ class RDSConnection(AWSQueryConnection):
                   'AllocatedStorage' : allocated_storage,
                   'DBInstanceClass' : instance_class,
                   'Engine' : engine,
-                  'MasterUsername' : master_username,
-                  'MasterUserPassword' : master_password}
+                  'MainUsername' : main_username,
+                  'MainUserPassword' : main_password}
         if port:
             params['Port'] = port
         if db_name:
@@ -190,7 +190,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -210,8 +210,8 @@ class RDSConnection(AWSQueryConnection):
                                              which maintenance can occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -258,8 +258,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/vendor/boto/boto/rds/dbinstance.py
+++ b/vendor/boto/boto/rds/dbinstance.py
@@ -36,7 +36,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -77,8 +77,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)

--- a/vendor/boto/boto/rds/dbsnapshot.py
+++ b/vendor/boto/boto/rds/dbsnapshot.py
@@ -33,7 +33,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -61,8 +61,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/vendor/boto/docs/source/conf.py
+++ b/vendor/boto/docs/source/conf.py
@@ -5,7 +5,7 @@ import sys, os
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo']
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 project = u'boto'
 copyright = u'2009,2010, Mitch Garnaat'
 version = '1.9'

--- a/vendor/lockfile/doc/conf.py
+++ b/vendor/lockfile/doc/conf.py
@@ -31,8 +31,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'lockfile'
+# The main toctree document.
+main_doc = 'lockfile'
 
 # General substitutions.
 project = 'lockfile'

--- a/vendor/tornado/website/markdown/blockprocessors.py
+++ b/vendor/tornado/website/markdown/blockprocessors.py
@@ -209,7 +209,7 @@ class CodeBlockProcessor(BlockProcessor):
             code.text = markdown.AtomicString('%s\n' % block.rstrip())
         if theRest:
             # This block contained unindented line(s) after the first indented 
-            # line. Insert these lines as the first block of the master blocks
+            # line. Insert these lines as the first block of the main blocks
             # list for future processing.
             blocks.insert(0, theRest)
 
@@ -377,7 +377,7 @@ class SetextHeaderProcessor(BlockProcessor):
         h = markdown.etree.SubElement(parent, 'h%d' % level)
         h.text = lines[0].strip()
         if len(lines) > 2:
-            # Block contains additional lines. Add to  master blocks for later.
+            # Block contains additional lines. Add to  main blocks for later.
             blocks.insert(0, '\n'.join(lines[2:]))
 
 
@@ -411,7 +411,7 @@ class HRProcessor(BlockProcessor):
         # check for lines in block after hr.
         lines = lines[len(prelines)+1:]
         if len(lines):
-            # Add lines after hr to master blocks for later parsing.
+            # Add lines after hr to main blocks for later parsing.
             blocks.insert(0, '\n'.join(lines))
 
 
@@ -429,7 +429,7 @@ class EmptyBlockProcessor(BlockProcessor):
         block = blocks.pop(0)
         m = self.RE.match(block)
         if m:
-            # Add remaining line to master blocks for later.
+            # Add remaining line to main blocks for later.
             blocks.insert(0, block[m.end():])
             sibling = self.lastChild(parent)
             if sibling and sibling.tag == 'pre' and sibling[0] and \


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.